### PR TITLE
Add boundary tests for deque_of_unique and vector_of_unique

### DIFF
--- a/tests/test_dequeofunique.cpp
+++ b/tests/test_dequeofunique.cpp
@@ -1162,6 +1162,15 @@ TEST(DequeOfUniqueTest, PushFront_EmptyRvalue) {
   EXPECT_THAT(dou.set(), ::testing::UnorderedElementsAreArray(expected));
 }
 
+TEST(DequeOfUniqueTest, PushFront_EmptyContainer) {
+  deque_of_unique<std::string> dou;
+  bool result = dou.push_front("hello");
+  EXPECT_TRUE(result);
+  EXPECT_EQ(dou.size(), 1);
+  EXPECT_EQ(dou.front(), "hello");
+  EXPECT_THAT(dou.set(), ::testing::UnorderedElementsAre("hello"));
+}
+
 TEST(DequeOfUniqueTest, PushBack_NewElement) {
   deque_of_unique<std::string> dou = {"hello", "world"};
   std::deque<std::string> expected = {"hello", "world", "good"};

--- a/tests/test_dequeofunique.cpp
+++ b/tests/test_dequeofunique.cpp
@@ -722,6 +722,16 @@ TEST(DequeOfUniqueTest, InsertAtSpecificPosition) {
             (std::deque<std::string>{"hello", "goodbye", "world"}));
 }
 
+TEST(DequeOfUniqueTest, Insert_DuplicateRvalue_SourceNotMoved) {
+  deque_of_unique<std::string> dou = {"hello", "world"};
+  std::string str = "hello";
+  auto result = dou.insert(dou.cbegin(), std::move(str));
+  EXPECT_FALSE(result.second);
+  // NOLINTNEXTLINE(bugprone-use-after-move,-warnings-as-errors)
+  EXPECT_EQ(str, "hello");
+  EXPECT_EQ(dou.deque(), (std::deque<std::string>{"hello", "world"}));
+}
+
 TEST(DequeOfUniqueTest, EmplaceIntoEmpty) {
   deque_of_unique<std::string> dou;
   std::deque<std::string> dq;

--- a/tests/test_dequeofunique.cpp
+++ b/tests/test_dequeofunique.cpp
@@ -548,6 +548,13 @@ TEST(DequeOfUniqueTest, BeginEnd_ConstCorrectness) {
       std::is_const<std::remove_reference_t<decltype(*dou.begin())>>::value);
 }
 
+TEST(DequeOfUniqueTest, Clear_EmptyContainer) {
+  deque_of_unique<int> dou;
+  EXPECT_NO_THROW(dou.clear());
+  EXPECT_TRUE(dou.empty());
+  EXPECT_TRUE(dou.set().empty());
+}
+
 TEST(DequeOfUniqueTest, Clear) {
   deque_of_unique<int> dou = {1, 2, 3, 4, 5};
   static_assert(noexcept(dou.clear()), "clear() should be noexcept.");
@@ -1623,4 +1630,10 @@ TEST(DequeOfUniqueTest, EraseIfWithComplexPredicate) {
   EXPECT_EQ(dou.size(), 2);
   EXPECT_TRUE(dou.find("banana") == dou.cend());
   EXPECT_TRUE(dou.find("cherry") == dou.cend());
+}
+
+TEST(DequeOfUniqueTest, EraseIf_RemainingElementsPreserveOrder) {
+  deque_of_unique<int> dou = {1, 2, 3, 4, 5, 6};
+  erase_if(dou, [](int x) { return x % 2 == 0; });
+  EXPECT_EQ(dou.deque(), std::deque<int>({1, 3, 5}));
 }

--- a/tests/test_dequeofunique.cpp
+++ b/tests/test_dequeofunique.cpp
@@ -564,6 +564,20 @@ TEST(DequeOfUniqueTest, Clear) {
   EXPECT_THAT(dou.set(), ::testing::UnorderedElementsAre());
 }
 
+TEST(DequeOfUniqueTest, Erase_ReturnsNextIterator) {
+  deque_of_unique<int> dou = {1, 2, 3, 4, 5};
+  auto it = dou.erase(dou.cbegin());
+  EXPECT_EQ(*it, 2);
+}
+
+TEST(DequeOfUniqueTest, Erase_LastElement_ReturnsEnd) {
+  deque_of_unique<int> dou = {1, 2, 3};
+  auto it = dou.erase(dou.cend() - 1);
+  EXPECT_EQ(it, dou.cend());
+  EXPECT_EQ(dou.size(), 2);
+  EXPECT_EQ(dou.back(), 2);
+}
+
 TEST(DequeOfUniqueTest, Erase_SingleElement) {
   deque_of_unique<int> dou = {1, 2, 3, 4, 5};
   std::deque<int> expected_deque = {2, 3, 4, 5};

--- a/tests/test_dequeofunique.cpp
+++ b/tests/test_dequeofunique.cpp
@@ -24,6 +24,13 @@ TEST(DequeOfUniqueTest, DefaultConstructor) {
   EXPECT_THAT(dou.set(), ::testing::UnorderedElementsAreArray(emptyset));
 }
 
+TEST(DequeOfUniqueTest, ConstructorFromEmptyRange) {
+  std::deque<int> empty;
+  deque_of_unique<int> dou(empty.begin(), empty.end());
+  EXPECT_TRUE(dou.empty());
+  EXPECT_TRUE(dou.set().empty());
+}
+
 TEST(DequeOfUniqueTest, ConstructorInitializesFromIterators) {
   std::deque<int> dq1 = {3, 1, 2, 3, 4, 5};
   std::deque<int> dq2 = {3, 1, 2, 4, 5};
@@ -106,6 +113,14 @@ TEST(DequeOfUniqueTest, MoveConstructor) {
   EXPECT_EQ(dou2.deque(), dq);
 }
 
+TEST(DequeOfUniqueTest, MoveConstructor_SourceIsEmpty) {
+  deque_of_unique<int> dou1 = {1, 2, 3, 4};
+  deque_of_unique<int> dou2(std::move(dou1));
+  EXPECT_EQ(dou2.deque(), std::deque<int>({1, 2, 3, 4}));
+  EXPECT_TRUE(dou1.empty());
+  EXPECT_TRUE(dou1.set().empty());
+}
+
 TEST(DequeOfUniqueTest, CopyAssignmentOperator) {
   deque_of_unique<int> dou1 = {1, 2, 3, 4};
   deque_of_unique<int> dou2 = dou1;
@@ -162,6 +177,16 @@ TEST(DequeOfUniqueTest, InitializerListAssignmentOperator) {
   EXPECT_EQ(dou.deque(), dq);
   EXPECT_THAT(std::deque<int>(dou.set().begin(), dou.set().end()),
               ::testing::UnorderedElementsAreArray(dq));
+}
+
+TEST(DequeOfUniqueTest, InitializerListAssignment_OverwritesNonEmpty) {
+  deque_of_unique<int> dou = {1, 2, 3};
+  dou = {4, 5, 6};
+  EXPECT_EQ(dou.deque(), std::deque<int>({4, 5, 6}));
+  EXPECT_EQ(dou.size(), 3);
+  EXPECT_FALSE(dou.find(1) != dou.cend());
+  EXPECT_FALSE(dou.find(2) != dou.cend());
+  EXPECT_FALSE(dou.find(3) != dou.cend());
 }
 
 TEST(DequeOfUniqueTest, AssignEmptyRange) {

--- a/tests/test_dequeofunique.cpp
+++ b/tests/test_dequeofunique.cpp
@@ -117,7 +117,9 @@ TEST(DequeOfUniqueTest, MoveConstructor_SourceIsEmpty) {
   deque_of_unique<int> dou1 = {1, 2, 3, 4};
   deque_of_unique<int> dou2(std::move(dou1));
   EXPECT_EQ(dou2.deque(), std::deque<int>({1, 2, 3, 4}));
+  // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move,-warnings-as-errors)
   EXPECT_TRUE(dou1.empty());
+  // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move,-warnings-as-errors)
   EXPECT_TRUE(dou1.set().empty());
 }
 

--- a/tests/test_vectorofunique.cpp
+++ b/tests/test_vectorofunique.cpp
@@ -565,6 +565,20 @@ TEST(VectorOfUniqueTest, Clear) {
   EXPECT_THAT(vou.set(), ::testing::UnorderedElementsAre());
 }
 
+TEST(VectorOfUniqueTest, Erase_ReturnsNextIterator) {
+  vector_of_unique<int> vou = {1, 2, 3, 4, 5};
+  auto it = vou.erase(vou.cbegin());
+  EXPECT_EQ(*it, 2);
+}
+
+TEST(VectorOfUniqueTest, Erase_LastElement_ReturnsEnd) {
+  vector_of_unique<int> vou = {1, 2, 3};
+  auto it = vou.erase(vou.cend() - 1);
+  EXPECT_EQ(it, vou.cend());
+  EXPECT_EQ(vou.size(), 2);
+  EXPECT_EQ(vou.back(), 2);
+}
+
 TEST(VectorOfUniqueTest, Erase_SingleElement) {
   vector_of_unique<int> vou = {1, 2, 3, 4, 5};
   std::vector<int> expected_vector = {2, 3, 4, 5};

--- a/tests/test_vectorofunique.cpp
+++ b/tests/test_vectorofunique.cpp
@@ -724,6 +724,16 @@ TEST(VectorOfUniqueTest, InsertAtSpecificPosition) {
             (std::vector<std::string>{"hello", "goodbye", "world"}));
 }
 
+TEST(VectorOfUniqueTest, Insert_DuplicateRvalue_SourceNotMoved) {
+  vector_of_unique<std::string> vou = {"hello", "world"};
+  std::string str = "hello";
+  auto result = vou.insert(vou.cbegin(), std::move(str));
+  EXPECT_FALSE(result.second);
+  // NOLINTNEXTLINE(bugprone-use-after-move,-warnings-as-errors)
+  EXPECT_EQ(str, "hello");
+  EXPECT_EQ(vou.vector(), (std::vector<std::string>{"hello", "world"}));
+}
+
 TEST(VectorOfUniqueTest, EmplaceIntoEmpty) {
   vector_of_unique<std::string> vou;
   std::vector<std::string> vec;

--- a/tests/test_vectorofunique.cpp
+++ b/tests/test_vectorofunique.cpp
@@ -24,6 +24,13 @@ TEST(VectorOfUniqueTest, DefaultConstructor) {
   EXPECT_THAT(vou.set(), ::testing::UnorderedElementsAreArray(emptyset));
 }
 
+TEST(VectorOfUniqueTest, ConstructorFromEmptyRange) {
+  std::vector<int> empty;
+  vector_of_unique<int> vou(empty.begin(), empty.end());
+  EXPECT_TRUE(vou.empty());
+  EXPECT_TRUE(vou.set().empty());
+}
+
 TEST(VectorOfUniqueTest, ConstructorInitializesFromIterators) {
   std::vector<int> vec1 = {3, 1, 2, 3, 4, 5};
   std::vector<int> vec2 = {3, 1, 2, 4, 5};
@@ -106,6 +113,14 @@ TEST(VectorOfUniqueTest, MoveConstructor) {
   EXPECT_EQ(vou2.vector(), vec);
 }
 
+TEST(VectorOfUniqueTest, MoveConstructor_SourceIsEmpty) {
+  vector_of_unique<int> vou1 = {1, 2, 3, 4};
+  vector_of_unique<int> vou2(std::move(vou1));
+  EXPECT_EQ(vou2.vector(), std::vector<int>({1, 2, 3, 4}));
+  EXPECT_TRUE(vou1.empty());
+  EXPECT_TRUE(vou1.set().empty());
+}
+
 TEST(VectorOfUniqueTest, CopyAssignmentOperator) {
   vector_of_unique<int> vou1 = {1, 2, 3, 4};
   vector_of_unique<int> vou2 = vou1;
@@ -162,6 +177,16 @@ TEST(VectorOfUniqueTest, InitializerListAssignmentOperator) {
   EXPECT_EQ(vou.vector(), vec);
   EXPECT_THAT(std::vector<int>(vou.set().begin(), vou.set().end()),
               ::testing::UnorderedElementsAreArray(vec));
+}
+
+TEST(VectorOfUniqueTest, InitializerListAssignment_OverwritesNonEmpty) {
+  vector_of_unique<int> vou = {1, 2, 3};
+  vou = {4, 5, 6};
+  EXPECT_EQ(vou.vector(), std::vector<int>({4, 5, 6}));
+  EXPECT_EQ(vou.size(), 3);
+  EXPECT_FALSE(vou.find(1) != vou.cend());
+  EXPECT_FALSE(vou.find(2) != vou.cend());
+  EXPECT_FALSE(vou.find(3) != vou.cend());
 }
 
 TEST(VectorOfUniqueTest, AssignEmptyRange) {

--- a/tests/test_vectorofunique.cpp
+++ b/tests/test_vectorofunique.cpp
@@ -117,7 +117,9 @@ TEST(VectorOfUniqueTest, MoveConstructor_SourceIsEmpty) {
   vector_of_unique<int> vou1 = {1, 2, 3, 4};
   vector_of_unique<int> vou2(std::move(vou1));
   EXPECT_EQ(vou2.vector(), std::vector<int>({1, 2, 3, 4}));
+  // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move,-warnings-as-errors)
   EXPECT_TRUE(vou1.empty());
+  // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move,-warnings-as-errors)
   EXPECT_TRUE(vou1.set().empty());
 }
 

--- a/tests/test_vectorofunique.cpp
+++ b/tests/test_vectorofunique.cpp
@@ -550,6 +550,13 @@ TEST(VectorOfUniqueTest, BeginEnd_ConstCorrectness) {
       std::is_const<std::remove_reference_t<decltype(*vou.begin())>>::value);
 }
 
+TEST(VectorOfUniqueTest, Clear_EmptyContainer) {
+  vector_of_unique<int> vou;
+  EXPECT_NO_THROW(vou.clear());
+  EXPECT_TRUE(vou.empty());
+  EXPECT_TRUE(vou.set().empty());
+}
+
 TEST(VectorOfUniqueTest, Clear) {
   vector_of_unique<int> vou = {1, 2, 3, 4, 5};
   vou.clear();
@@ -1373,4 +1380,10 @@ TEST(VectorOfUniqueTest, EraseIfWithComplexPredicate) {
   EXPECT_EQ(vou.size(), 2);
   EXPECT_TRUE(vou.find("banana") == vou.cend());
   EXPECT_TRUE(vou.find("cherry") == vou.cend());
+}
+
+TEST(VectorOfUniqueTest, EraseIf_RemainingElementsPreserveOrder) {
+  vector_of_unique<int> vou = {1, 2, 3, 4, 5, 6};
+  erase_if(vou, [](int x) { return x % 2 == 0; });
+  EXPECT_EQ(vou.vector(), std::vector<int>({1, 3, 5}));
 }


### PR DESCRIPTION
## Summary
- Add `ConstructorFromEmptyRange` test for both containers
- Add `MoveConstructor_SourceIsEmpty` test verifying source is empty after move
- Add `InitializerListAssignment_OverwritesNonEmpty` test verifying old elements are cleared from set
- Add `PushFront_EmptyContainer` test for `deque_of_unique`
- Add `Insert_DuplicateRvalue_SourceNotMoved` test verifying failed rvalue insert does not consume source value
- Add `Clear_EmptyContainer` test for both containers
- Add `Erase_ReturnsNextIterator` and `Erase_LastElement_ReturnsEnd` tests for both containers
- Add `EraseIf_RemainingElementsPreserveOrder` test for both containers

Closes #13
Closes #14
Closes #15
Closes #16
Closes #17
Closes #18
Closes #19
Closes #20

## Test plan
- [x] All new tests pass under C++14/17/20/23

🤖 Generated with [Claude Code](https://claude.com/claude-code)