### PR TITLE
Remove empty() guard in erase(pos) and speed up CI

### DIFF
--- a/src/dequeofunique.h
+++ b/src/dequeofunique.h
@@ -93,10 +93,10 @@ class deque_of_unique {
     set_.clear();
   }
 
+  // Precondition: pos must be a valid and dereferenceable iterator of this
+  // container (i.e. pos != cend()). Violating this is undefined behaviour,
+  // matching the contract of std::deque::erase.
   const_iterator erase(const_iterator pos) {
-    if (deque_.empty()) {
-      return deque_.cend();
-    }
     set_.erase(*pos);
     return deque_.erase(pos);
   }

--- a/src/vectorofunique.h
+++ b/src/vectorofunique.h
@@ -93,10 +93,10 @@ class vector_of_unique {
     set_.clear();
   }
 
+  // Precondition: pos must be a valid and dereferenceable iterator of this
+  // container (i.e. pos != cend()). Violating this is undefined behaviour,
+  // matching the contract of std::vector::erase.
   const_iterator erase(const_iterator pos) {
-    if (vector_.empty()) {
-      return vector_.cend();
-    }
     set_.erase(*pos);
     return vector_.erase(pos);
   }

--- a/tests/test_dequeofunique.cpp
+++ b/tests/test_dequeofunique.cpp
@@ -590,12 +590,6 @@ TEST(DequeOfUniqueTest, Erase_SingleElement) {
   EXPECT_THAT(dou.set(), ::testing::UnorderedElementsAreArray(expected_set));
 }
 
-TEST(DequeOfUniqueTest, Erase_FromEmptyContainer) {
-  deque_of_unique<int> dou;
-  EXPECT_NO_THROW(dou.erase(dou.cbegin()));
-  EXPECT_EQ(dou.deque().size(), 0);
-}
-
 TEST(DequeOfUniqueTest, EraseEmptyRange) {
   deque_of_unique<int> dou1 = {1, 2, 3, 4, 5, 6};
   std::deque<int> dq2 = {1, 2, 3, 4, 5, 6};

--- a/tests/test_vectorofunique.cpp
+++ b/tests/test_vectorofunique.cpp
@@ -591,12 +591,6 @@ TEST(VectorOfUniqueTest, Erase_SingleElement) {
   EXPECT_THAT(vou.set(), ::testing::UnorderedElementsAreArray(expected_set));
 }
 
-TEST(VectorOfUniqueTest, Erase_FromEmptyContainer) {
-  vector_of_unique<int> vou;
-  EXPECT_NO_THROW(vou.erase(vou.cbegin()));
-  EXPECT_EQ(vou.vector().size(), 0);
-}
-
 TEST(VectorOfUniqueTest, EraseEmptyRange) {
   vector_of_unique<int> vou1 = {1, 2, 3, 4, 5, 6};
   std::vector<int> vec2 = {1, 2, 3, 4, 5, 6};


### PR DESCRIPTION
## Summary

- Removes the misleading `empty()` guard in `erase(const_iterator pos)` for both `vector_of_unique` and `deque_of_unique`, following Design by Contract: `pos` must be valid and dereferenceable, matching the precondition of `std::vector/std::deque::erase` (fixes #8)
- Speeds up the GitHub Actions clang-tidy step by switching to parallel execution with `run-clang-tidy -j$(nproc)`

## Test plan

- [ ] All existing tests pass across C++14/17/20/23 for both containers
- [ ] `Erase_FromEmptyContainer` tests removed (tested behaviour that violated the precondition)
- [ ] CI clang-tidy step runs significantly faster than the previous ~10 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)