### PR TITLE
Add member function erase(const key_type&) for value-based deletion

### DIFF
--- a/src/dequeofunique.h
+++ b/src/dequeofunique.h
@@ -101,6 +101,15 @@ class deque_of_unique {
     return deque_.erase(pos);
   }
 
+  size_type erase(const key_type &value) {
+    auto it = find(value);
+    if (it != cend()) {
+      erase(it);
+      return 1;
+    }
+    return 0;
+  }
+
   const_iterator erase(const_iterator first, const_iterator last) {
     if (first == last) {
       return last;

--- a/src/vectorofunique.h
+++ b/src/vectorofunique.h
@@ -101,6 +101,15 @@ class vector_of_unique {
     return vector_.erase(pos);
   }
 
+  size_type erase(const key_type &value) {
+    auto it = find(value);
+    if (it != cend()) {
+      erase(it);
+      return 1;
+    }
+    return 0;
+  }
+
   const_iterator erase(const_iterator first, const_iterator last) {
     if (first == last) {
       return last;

--- a/tests/test_dequeofunique.cpp
+++ b/tests/test_dequeofunique.cpp
@@ -628,6 +628,46 @@ TEST(DequeOfUniqueTest, EraseAllElements) {
   EXPECT_THAT(dou1.set(), ::testing::UnorderedElementsAreArray(set2));
 }
 
+TEST(DequeOfUniqueTest, EraseByValue_Exists) {
+  deque_of_unique<int> dou = {1, 2, 3, 4, 5};
+  EXPECT_EQ(dou.erase(3), 1);
+  EXPECT_EQ(dou.deque(), (std::deque<int>{1, 2, 4, 5}));
+  EXPECT_EQ(dou.set().size(), 4);
+  EXPECT_FALSE(dou.find(3) != dou.cend());
+}
+
+TEST(DequeOfUniqueTest, EraseByValue_NotExists) {
+  deque_of_unique<int> dou = {1, 2, 3};
+  EXPECT_EQ(dou.erase(99), 0);
+  EXPECT_EQ(dou.deque(), (std::deque<int>{1, 2, 3}));
+  EXPECT_EQ(dou.size(), 3);
+}
+
+TEST(DequeOfUniqueTest, EraseByValue_Empty) {
+  deque_of_unique<int> dou;
+  EXPECT_EQ(dou.erase(1), 0);
+  EXPECT_TRUE(dou.empty());
+}
+
+TEST(DequeOfUniqueTest, EraseByValue_First) {
+  deque_of_unique<int> dou = {1, 2, 3};
+  EXPECT_EQ(dou.erase(1), 1);
+  EXPECT_EQ(dou.deque(), (std::deque<int>{2, 3}));
+}
+
+TEST(DequeOfUniqueTest, EraseByValue_Last) {
+  deque_of_unique<int> dou = {1, 2, 3};
+  EXPECT_EQ(dou.erase(3), 1);
+  EXPECT_EQ(dou.deque(), (std::deque<int>{1, 2}));
+}
+
+TEST(DequeOfUniqueTest, EraseByValue_OnlyElement) {
+  deque_of_unique<int> dou = {42};
+  EXPECT_EQ(dou.erase(42), 1);
+  EXPECT_TRUE(dou.empty());
+  EXPECT_TRUE(dou.set().empty());
+}
+
 TEST(DequeOfUniqueTest, InsertLvalueRvalue) {
   std::cout << "Test inserting a unique element" << '\n';
   deque_of_unique<int> dou1 = {1};

--- a/tests/test_vectorofunique.cpp
+++ b/tests/test_vectorofunique.cpp
@@ -629,6 +629,46 @@ TEST(VectorOfUniqueTest, EraseAllElements) {
   EXPECT_THAT(vou1.set(), ::testing::UnorderedElementsAreArray(set2));
 }
 
+TEST(VectorOfUniqueTest, EraseByValue_Exists) {
+  vector_of_unique<int> vou = {1, 2, 3, 4, 5};
+  EXPECT_EQ(vou.erase(3), 1);
+  EXPECT_EQ(vou.vector(), (std::vector<int>{1, 2, 4, 5}));
+  EXPECT_EQ(vou.set().size(), 4);
+  EXPECT_FALSE(vou.find(3) != vou.cend());
+}
+
+TEST(VectorOfUniqueTest, EraseByValue_NotExists) {
+  vector_of_unique<int> vou = {1, 2, 3};
+  EXPECT_EQ(vou.erase(99), 0);
+  EXPECT_EQ(vou.vector(), (std::vector<int>{1, 2, 3}));
+  EXPECT_EQ(vou.size(), 3);
+}
+
+TEST(VectorOfUniqueTest, EraseByValue_Empty) {
+  vector_of_unique<int> vou;
+  EXPECT_EQ(vou.erase(1), 0);
+  EXPECT_TRUE(vou.empty());
+}
+
+TEST(VectorOfUniqueTest, EraseByValue_First) {
+  vector_of_unique<int> vou = {1, 2, 3};
+  EXPECT_EQ(vou.erase(1), 1);
+  EXPECT_EQ(vou.vector(), (std::vector<int>{2, 3}));
+}
+
+TEST(VectorOfUniqueTest, EraseByValue_Last) {
+  vector_of_unique<int> vou = {1, 2, 3};
+  EXPECT_EQ(vou.erase(3), 1);
+  EXPECT_EQ(vou.vector(), (std::vector<int>{1, 2}));
+}
+
+TEST(VectorOfUniqueTest, EraseByValue_OnlyElement) {
+  vector_of_unique<int> vou = {42};
+  EXPECT_EQ(vou.erase(42), 1);
+  EXPECT_TRUE(vou.empty());
+  EXPECT_TRUE(vou.set().empty());
+}
+
 TEST(VectorOfUniqueTest, InsertLvalueRvalue) {
   std::cout << "Test inserting a unique element" << '\n';
   vector_of_unique<int> vou1 = {1};


### PR DESCRIPTION
## Summary
- Add `erase(const key_type& value)` member function to both `deque_of_unique` and `vector_of_unique`
- Returns `1` if the element was found and erased, `0` otherwise — matching the semantics of `std::unordered_set::erase`
- Add 6 tests per container covering: exists, not exists, empty container, first element, last element, only element

Closes #9

## Test plan
- [x] All tests pass under C++14/17/20/23
- [x] clang-format OK
- [x] clang-tidy OK (local)

🤖 Generated with [Claude Code](https://claude.com/claude-code)