### PR TITLE
Add range modifier methods and equal_range (fixes #28 #29 #30 #31 #32)

### DIFF
--- a/src/dequeofunique.h
+++ b/src/dequeofunique.h
@@ -6,6 +6,9 @@
 #include <optional>  // For std::nullopt
 #include <unordered_set>
 #include <utility>  // For std::swap
+#if __cplusplus >= 202302L
+#include <ranges>
+#endif
 
 #if __cplusplus >= 201703L
 #define NOEXCEPT_CXX17 noexcept
@@ -70,6 +73,15 @@ class deque_of_unique {
     clear();
     _push_back(ilist.begin(), ilist.end());
   }
+
+#if __cplusplus >= 202302L
+  template <std::ranges::input_range R>
+  void assign_range(R&& rng) {
+    clear();
+    for (auto&& v : std::forward<R>(rng))
+      push_back(std::forward<decltype(v)>(v));
+  }
+#endif
 
   // Element access
   const_reference at(size_type pos) const { return deque_.at(pos); }
@@ -151,6 +163,28 @@ class deque_of_unique {
   const_iterator insert(const_iterator pos, std::initializer_list<T> ilist) {
     return insert(pos, ilist.begin(), ilist.end());
   }
+
+#if __cplusplus >= 202302L
+  template <std::ranges::input_range R>
+  const_iterator insert_range(const_iterator pos, R&& rng) {
+    auto pos_index = pos - deque_.cbegin();
+    auto first_inserted_index = pos_index;
+    auto temp_pos = deque_.begin() + pos_index;
+    auto any_inserted = false;
+    for (auto&& v : std::forward<R>(rng)) {
+      if (set_.insert(v).second) {
+        temp_pos = deque_.insert(temp_pos, std::forward<decltype(v)>(v));
+        if (!any_inserted) {
+          first_inserted_index = temp_pos - deque_.cbegin();
+          any_inserted = true;
+        }
+        ++temp_pos;
+      }
+    }
+    return any_inserted ? first_inserted_index + deque_.cbegin()
+                        : pos_index + deque_.cbegin();
+  }
+#endif
 
   template <class... Args>
   std::pair<const_iterator, bool> emplace(const_iterator pos, Args&&... args) {
@@ -245,6 +279,25 @@ class deque_of_unique {
     return true;
   }
 
+#if __cplusplus >= 202302L
+  template <std::ranges::input_range R>
+  void prepend_range(R&& rng) {
+    std::deque<std::ranges::range_value_t<R>> tmp;
+    unordered_set_type seen(0, set_.hash_function(), set_.key_eq());
+    for (auto&& v : std::forward<R>(rng)) {
+      if (!set_.count(v) && seen.insert(v).second) tmp.push_back(v);
+    }
+    for (auto it = tmp.rbegin(); it != tmp.rend(); ++it)
+      push_front(std::move(*it));
+  }
+
+  template <std::ranges::input_range R>
+  void append_range(R&& rng) {
+    for (auto&& v : std::forward<R>(rng))
+      push_back(std::forward<decltype(v)>(v));
+  }
+#endif
+
  private:
   template <class input_it>
   void _push_back(input_it first, input_it last) {
@@ -338,6 +391,26 @@ class deque_of_unique {
     }
   bool contains(const K& x) const {
     return set_.contains(x);
+  }
+#endif
+
+  std::pair<const_iterator, const_iterator> equal_range(
+      const key_type& key) const {
+    auto it = find(key);
+    if (it == cend()) return {cend(), cend()};
+    return {it, it + 1};
+  }
+
+#if __cplusplus >= 202002L
+  template <class K>
+    requires requires {
+      typename Hash::is_transparent;
+      typename KeyEqual::is_transparent;
+    }
+  std::pair<const_iterator, const_iterator> equal_range(const K& x) const {
+    auto it = find(x);
+    if (it == cend()) return {cend(), cend()};
+    return {it, it + 1};
   }
 #endif
 

--- a/src/vectorofunique.h
+++ b/src/vectorofunique.h
@@ -6,6 +6,9 @@
 #include <unordered_set>
 #include <utility>  // For std::swap
 #include <vector>
+#if __cplusplus >= 202302L
+#include <ranges>
+#endif
 
 #if __cplusplus >= 201703L
 #define NOEXCEPT_CXX17 noexcept
@@ -70,6 +73,15 @@ class vector_of_unique {
     clear();
     _push_back(ilist.begin(), ilist.end());
   }
+
+#if __cplusplus >= 202302L
+  template <std::ranges::input_range R>
+  void assign_range(R&& rng) {
+    clear();
+    for (auto&& v : std::forward<R>(rng))
+      push_back(std::forward<decltype(v)>(v));
+  }
+#endif
 
   // Element access
   const_reference at(size_type pos) const { return vector_.at(pos); }
@@ -152,6 +164,28 @@ class vector_of_unique {
     return insert(pos, ilist.begin(), ilist.end());
   }
 
+#if __cplusplus >= 202302L
+  template <std::ranges::input_range R>
+  const_iterator insert_range(const_iterator pos, R&& rng) {
+    auto pos_index = pos - vector_.cbegin();
+    auto first_inserted_index = pos_index;
+    auto temp_pos = vector_.begin() + pos_index;
+    auto any_inserted = false;
+    for (auto&& v : std::forward<R>(rng)) {
+      if (set_.insert(v).second) {
+        temp_pos = vector_.insert(temp_pos, std::forward<decltype(v)>(v));
+        if (!any_inserted) {
+          first_inserted_index = temp_pos - vector_.cbegin();
+          any_inserted = true;
+        }
+        ++temp_pos;
+      }
+    }
+    return any_inserted ? first_inserted_index + vector_.cbegin()
+                        : pos_index + vector_.cbegin();
+  }
+#endif
+
   template <class... Args>
   std::pair<const_iterator, bool> emplace(const_iterator pos, Args&&... args) {
     if (set_.emplace(args...).second) {
@@ -202,6 +236,14 @@ class vector_of_unique {
     vector_.push_back(std::move(value));
     return true;
   }
+
+#if __cplusplus >= 202302L
+  template <std::ranges::input_range R>
+  void append_range(R&& rng) {
+    for (auto&& v : std::forward<R>(rng))
+      push_back(std::forward<decltype(v)>(v));
+  }
+#endif
 
  private:
   template <class input_it>
@@ -296,6 +338,26 @@ class vector_of_unique {
     }
   bool contains(const K& x) const {
     return set_.contains(x);
+  }
+#endif
+
+  std::pair<const_iterator, const_iterator> equal_range(
+      const key_type& key) const {
+    auto it = find(key);
+    if (it == cend()) return {cend(), cend()};
+    return {it, it + 1};
+  }
+
+#if __cplusplus >= 202002L
+  template <class K>
+    requires requires {
+      typename Hash::is_transparent;
+      typename KeyEqual::is_transparent;
+    }
+  std::pair<const_iterator, const_iterator> equal_range(const K& x) const {
+    auto it = find(x);
+    if (it == cend()) return {cend(), cend()};
+    return {it, it + 1};
   }
 #endif
 

--- a/tests/test_dequeofunique.cpp
+++ b/tests/test_dequeofunique.cpp
@@ -1523,19 +1523,14 @@ TEST(DequeOfUniqueTest, Find_HeterogeneousLookup) {
 }
 
 // Negative: find<K>/contains<K> are not available without Hash::is_transparent.
-// Use a type with no implicit conversion to std::string so the non-transparent
-// find(const T&) overload cannot accept it via implicit conversion.
-struct DequeOpaqueKey {
-  std::string value;
-  explicit DequeOpaqueKey(const char* s) : value(s) {}
-};
 template <typename C, typename K>
 concept DequeCanFindWith = requires(const C& c, K k) { c.find(k); };
 template <typename C, typename K>
 concept DequeCanContainsWith = requires(const C& c, K k) { c.contains(k); };
-static_assert(!DequeCanFindWith<deque_of_unique<std::string>, DequeOpaqueKey>);
 static_assert(
-    !DequeCanContainsWith<deque_of_unique<std::string>, DequeOpaqueKey>);
+    !DequeCanFindWith<deque_of_unique<std::string>, std::string_view>);
+static_assert(
+    !DequeCanContainsWith<deque_of_unique<std::string>, std::string_view>);
 #endif
 
 TEST(DequeOfUniqueTest, NonmemberEraseWithStrings) {
@@ -1692,3 +1687,120 @@ TEST(DequeOfUniqueTest, EraseIf_RemainingElementsPreserveOrder) {
   erase_if(dou, [](int x) { return x % 2 == 0; });
   EXPECT_EQ(dou.deque(), std::deque<int>({1, 3, 5}));
 }
+
+TEST(DequeOfUniqueTest, EqualRange_Found) {
+  deque_of_unique<int> dou = {10, 20, 30};
+  auto [lo, hi] = dou.equal_range(20);
+  ASSERT_NE(lo, dou.cend());
+  EXPECT_EQ(*lo, 20);
+  EXPECT_EQ(hi, lo + 1);
+}
+
+TEST(DequeOfUniqueTest, EqualRange_NotFound) {
+  deque_of_unique<int> dou = {10, 20, 30};
+  auto [lo, hi] = dou.equal_range(99);
+  EXPECT_EQ(lo, dou.cend());
+  EXPECT_EQ(hi, dou.cend());
+}
+
+TEST(DequeOfUniqueTest, EqualRange_Empty) {
+  deque_of_unique<int> dou;
+  auto [lo, hi] = dou.equal_range(1);
+  EXPECT_EQ(lo, dou.cend());
+  EXPECT_EQ(hi, dou.cend());
+}
+
+#if __cplusplus >= 202002L
+TEST(DequeOfUniqueTest, EqualRange_HeterogeneousLookup) {
+  deque_of_unique<std::string, StringHash, StringEqual> dou = {"hello",
+                                                               "world"};
+  auto [lo, hi] = dou.equal_range(std::string_view("hello"));
+  ASSERT_NE(lo, dou.cend());
+  EXPECT_EQ(*lo, "hello");
+  EXPECT_EQ(hi, lo + 1);
+
+  auto [lo2, hi2] = dou.equal_range(std::string_view("missing"));
+  EXPECT_EQ(lo2, dou.cend());
+  EXPECT_EQ(hi2, dou.cend());
+}
+#endif
+
+#if __cplusplus >= 202302L
+TEST(DequeOfUniqueTest, AssignRange_Basic) {
+  deque_of_unique<int> dou = {1, 2, 3};
+  std::vector<int> src = {4, 5, 6};
+  dou.assign_range(src);
+  EXPECT_EQ(dou.deque(), std::deque<int>({4, 5, 6}));
+}
+
+TEST(DequeOfUniqueTest, AssignRange_Deduplicates) {
+  deque_of_unique<int> dou;
+  std::vector<int> src = {1, 2, 2, 3, 1};
+  dou.assign_range(src);
+  EXPECT_EQ(dou.deque(), std::deque<int>({1, 2, 3}));
+}
+
+TEST(DequeOfUniqueTest, AssignRange_ClearsExisting) {
+  deque_of_unique<int> dou = {10, 20, 30};
+  std::vector<int> src = {1};
+  dou.assign_range(src);
+  EXPECT_EQ(dou.size(), 1);
+  EXPECT_EQ(dou.front(), 1);
+}
+
+TEST(DequeOfUniqueTest, InsertRange_Basic) {
+  deque_of_unique<int> dou = {1, 3};
+  std::vector<int> src = {2};
+  dou.insert_range(dou.cbegin() + 1, src);
+  EXPECT_EQ(dou.deque(), std::deque<int>({1, 2, 3}));
+}
+
+TEST(DequeOfUniqueTest, InsertRange_SkipsDuplicates) {
+  deque_of_unique<int> dou = {1, 2, 3};
+  std::vector<int> src = {2, 4};
+  dou.insert_range(dou.cend(), src);
+  EXPECT_EQ(dou.deque(), std::deque<int>({1, 2, 3, 4}));
+}
+
+TEST(DequeOfUniqueTest, AppendRange_Basic) {
+  deque_of_unique<int> dou = {1, 2};
+  std::vector<int> src = {3, 4};
+  dou.append_range(src);
+  EXPECT_EQ(dou.deque(), std::deque<int>({1, 2, 3, 4}));
+}
+
+TEST(DequeOfUniqueTest, AppendRange_SkipsDuplicates) {
+  deque_of_unique<int> dou = {1, 2};
+  std::vector<int> src = {2, 3};
+  dou.append_range(src);
+  EXPECT_EQ(dou.deque(), std::deque<int>({1, 2, 3}));
+}
+
+TEST(DequeOfUniqueTest, PrependRange_Basic) {
+  deque_of_unique<int> dou = {3, 4};
+  std::vector<int> src = {1, 2};
+  dou.prepend_range(src);
+  EXPECT_EQ(dou.deque(), std::deque<int>({1, 2, 3, 4}));
+}
+
+TEST(DequeOfUniqueTest, PrependRange_SkipsDuplicates) {
+  deque_of_unique<int> dou = {2, 3};
+  std::vector<int> src = {1, 2};
+  dou.prepend_range(src);
+  EXPECT_EQ(dou.deque(), std::deque<int>({1, 2, 3}));
+}
+
+TEST(DequeOfUniqueTest, PrependRange_PreservesOrder) {
+  deque_of_unique<int> dou = {4, 5};
+  std::vector<int> src = {1, 2, 3};
+  dou.prepend_range(src);
+  EXPECT_EQ(dou.deque(), std::deque<int>({1, 2, 3, 4, 5}));
+}
+
+TEST(DequeOfUniqueTest, PrependRange_IntraRangeDuplicates) {
+  deque_of_unique<int> dou = {4, 5};
+  std::vector<int> src = {1, 2, 1};
+  dou.prepend_range(src);
+  EXPECT_EQ(dou.deque(), std::deque<int>({1, 2, 4, 5}));
+}
+#endif

--- a/tests/test_vectorofunique.cpp
+++ b/tests/test_vectorofunique.cpp
@@ -1273,20 +1273,14 @@ TEST(VectorOfUniqueTest, Find_HeterogeneousLookup) {
 }
 
 // Negative: find<K>/contains<K> are not available without Hash::is_transparent.
-// Use a type with no implicit conversion to std::string so the non-transparent
-// find(const T&) overload cannot accept it via implicit conversion.
-struct VectorOpaqueKey {
-  std::string value;
-  explicit VectorOpaqueKey(const char* s) : value(s) {}
-};
 template <typename C, typename K>
 concept VectorCanFindWith = requires(const C& c, K k) { c.find(k); };
 template <typename C, typename K>
 concept VectorCanContainsWith = requires(const C& c, K k) { c.contains(k); };
 static_assert(
-    !VectorCanFindWith<vector_of_unique<std::string>, VectorOpaqueKey>);
+    !VectorCanFindWith<vector_of_unique<std::string>, std::string_view>);
 static_assert(
-    !VectorCanContainsWith<vector_of_unique<std::string>, VectorOpaqueKey>);
+    !VectorCanContainsWith<vector_of_unique<std::string>, std::string_view>);
 #endif
 
 TEST(VectorOfUniqueTest, NonmemberEraseWithStrings) {
@@ -1443,3 +1437,92 @@ TEST(VectorOfUniqueTest, EraseIf_RemainingElementsPreserveOrder) {
   erase_if(vou, [](int x) { return x % 2 == 0; });
   EXPECT_EQ(vou.vector(), std::vector<int>({1, 3, 5}));
 }
+
+TEST(VectorOfUniqueTest, EqualRange_Found) {
+  vector_of_unique<int> vou = {10, 20, 30};
+  auto [lo, hi] = vou.equal_range(20);
+  ASSERT_NE(lo, vou.cend());
+  EXPECT_EQ(*lo, 20);
+  EXPECT_EQ(hi, lo + 1);
+}
+
+TEST(VectorOfUniqueTest, EqualRange_NotFound) {
+  vector_of_unique<int> vou = {10, 20, 30};
+  auto [lo, hi] = vou.equal_range(99);
+  EXPECT_EQ(lo, vou.cend());
+  EXPECT_EQ(hi, vou.cend());
+}
+
+TEST(VectorOfUniqueTest, EqualRange_Empty) {
+  vector_of_unique<int> vou;
+  auto [lo, hi] = vou.equal_range(1);
+  EXPECT_EQ(lo, vou.cend());
+  EXPECT_EQ(hi, vou.cend());
+}
+
+#if __cplusplus >= 202002L
+TEST(VectorOfUniqueTest, EqualRange_HeterogeneousLookup) {
+  vector_of_unique<std::string, StringHash, StringEqual> vou = {"hello",
+                                                                "world"};
+  auto [lo, hi] = vou.equal_range(std::string_view("hello"));
+  ASSERT_NE(lo, vou.cend());
+  EXPECT_EQ(*lo, "hello");
+  EXPECT_EQ(hi, lo + 1);
+
+  auto [lo2, hi2] = vou.equal_range(std::string_view("missing"));
+  EXPECT_EQ(lo2, vou.cend());
+  EXPECT_EQ(hi2, vou.cend());
+}
+#endif
+
+#if __cplusplus >= 202302L
+TEST(VectorOfUniqueTest, AssignRange_Basic) {
+  vector_of_unique<int> vou = {1, 2, 3};
+  std::vector<int> src = {4, 5, 6};
+  vou.assign_range(src);
+  EXPECT_EQ(vou.vector(), std::vector<int>({4, 5, 6}));
+}
+
+TEST(VectorOfUniqueTest, AssignRange_Deduplicates) {
+  vector_of_unique<int> vou;
+  std::vector<int> src = {1, 2, 2, 3, 1};
+  vou.assign_range(src);
+  EXPECT_EQ(vou.vector(), std::vector<int>({1, 2, 3}));
+}
+
+TEST(VectorOfUniqueTest, AssignRange_ClearsExisting) {
+  vector_of_unique<int> vou = {10, 20, 30};
+  std::vector<int> src = {1};
+  vou.assign_range(src);
+  EXPECT_EQ(vou.size(), 1);
+  EXPECT_EQ(vou.front(), 1);
+}
+
+TEST(VectorOfUniqueTest, InsertRange_Basic) {
+  vector_of_unique<int> vou = {1, 3};
+  std::vector<int> src = {2};
+  vou.insert_range(vou.cbegin() + 1, src);
+  EXPECT_EQ(vou.vector(), std::vector<int>({1, 2, 3}));
+}
+
+TEST(VectorOfUniqueTest, InsertRange_SkipsDuplicates) {
+  vector_of_unique<int> vou = {1, 2, 3};
+  std::vector<int> src = {2, 4};
+  vou.insert_range(vou.cend(), src);
+  EXPECT_EQ(vou.vector(), std::vector<int>({1, 2, 3, 4}));
+}
+
+TEST(VectorOfUniqueTest, AppendRange_Basic) {
+  vector_of_unique<int> vou = {1, 2};
+  std::vector<int> src = {3, 4};
+  vou.append_range(src);
+  EXPECT_EQ(vou.vector(), std::vector<int>({1, 2, 3, 4}));
+}
+
+TEST(VectorOfUniqueTest, AppendRange_SkipsDuplicates) {
+  vector_of_unique<int> vou = {1, 2};
+  std::vector<int> src = {2, 3};
+  vou.append_range(src);
+  EXPECT_EQ(vou.vector(), std::vector<int>({1, 2, 3}));
+}
+#endif


### PR DESCRIPTION
## Summary

Adds C++23 range-modifier methods and `equal_range` lookup to both `deque_of_unique` and `vector_of_unique`:

- `assign_range` (C++23): clear and repopulate from a range, deduplicating
- `insert_range` (C++23): insert a range at a given position
- `append_range` (C++23): append a range to the back
- `prepend_range` (C++23, deque only): prepend a range to the front, preserving insertion order; correctly handles intra-range duplicates via a pending `unordered_set`
- `equal_range`: returns `{it, it+1}` if found, `{cend, cend}` if not; transparent overload gated on both `Hash::is_transparent` and `KeyEqual::is_transparent` (C++20)

Fixes #28, #29, #30, #31, #32.

## Test plan

- [x] All methods compile under C++14, C++17, C++20, C++23
- [x] C++23-gated methods absent in older standard builds
- [x] `prepend_range` preserves insertion order
- [x] `prepend_range` correctly deduplicates intra-range duplicates
- [x] Duplicates skipped in all range methods
- [x] `equal_range` heterogeneous overload only available with `Hash::is_transparent` + `KeyEqual::is_transparent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)