### PR TITLE
Full codebase review: initial commit → range methods

### DIFF
--- a/src/dequeofunique.h
+++ b/src/dequeofunique.h
@@ -10,10 +10,12 @@
 #include <ranges>
 #endif
 
+#ifndef NOEXCEPT_CXX17
 #if __cplusplus >= 201703L
 #define NOEXCEPT_CXX17 noexcept
 #else
 #define NOEXCEPT_CXX17
+#endif
 #endif
 
 namespace containerofunique {
@@ -254,12 +256,11 @@ class deque_of_unique {
   }
 
   bool push_front(T&& value) {
-    if (set_.count(value) > 0) {
-      return false;
+    if (set_.insert(value).second) {
+      deque_.push_front(std::move(value));
+      return true;
     }
-    set_.insert(value);
-    deque_.push_front(std::move(value));
-    return true;
+    return false;
   }
 
   bool push_back(const T& value) {
@@ -271,12 +272,11 @@ class deque_of_unique {
   }
 
   bool push_back(T&& value) {
-    if (set_.count(value) > 0) {
-      return false;
+    if (set_.insert(value).second) {
+      deque_.push_back(std::move(value));
+      return true;
     }
-    set_.insert(value);
-    deque_.push_back(std::move(value));
-    return true;
+    return false;
   }
 
 #if __cplusplus >= 202302L
@@ -306,7 +306,7 @@ class deque_of_unique {
     }
   }
 
-  bool _push_back(const deque_of_unique<T, Hash>& other) {
+  bool _push_back(const deque_of_unique<T, Hash, KeyEqual>& other) {
     return _push_back(other.deque_);
   }
 

--- a/src/dequeofunique.h
+++ b/src/dequeofunique.h
@@ -336,9 +336,10 @@ class deque_of_unique {
     if (set_.count(x) == 0) {
       return cend();
     }
+    auto eq = set_.key_eq();
     auto it = cbegin();
     while (it != cend()) {
-      if (*it == x) {
+      if (eq(*it, x)) {
         return it;
       }
       it++;
@@ -350,9 +351,10 @@ class deque_of_unique {
     if (set_.count(x) == 0) {
       return cend();
     }
+    auto eq = set_.key_eq();
     auto it = cbegin();
     while (it != cend()) {
-      if (*it == x) {
+      if (eq(*it, x)) {
         return it;
       }
       it++;

--- a/src/dequeofunique.h
+++ b/src/dequeofunique.h
@@ -6,6 +6,9 @@
 #include <optional>  // For std::nullopt
 #include <unordered_set>
 #include <utility>  // For std::swap
+#if __cplusplus >= 202302L
+#include <ranges>
+#endif
 
 #if __cplusplus >= 201703L
 #define NOEXCEPT_CXX17 noexcept
@@ -70,6 +73,15 @@ class deque_of_unique {
     clear();
     _push_back(ilist.begin(), ilist.end());
   }
+
+#if __cplusplus >= 202302L
+  template <std::ranges::input_range R>
+  void assign_range(R&& rng) {
+    clear();
+    for (auto&& v : std::forward<R>(rng))
+      push_back(std::forward<decltype(v)>(v));
+  }
+#endif
 
   // Element access
   const_reference at(size_type pos) const { return deque_.at(pos); }
@@ -151,6 +163,28 @@ class deque_of_unique {
   const_iterator insert(const_iterator pos, std::initializer_list<T> ilist) {
     return insert(pos, ilist.begin(), ilist.end());
   }
+
+#if __cplusplus >= 202302L
+  template <std::ranges::input_range R>
+  const_iterator insert_range(const_iterator pos, R&& rng) {
+    auto pos_index = pos - deque_.cbegin();
+    auto first_inserted_index = pos_index;
+    auto temp_pos = deque_.begin() + pos_index;
+    auto any_inserted = false;
+    for (auto&& v : std::forward<R>(rng)) {
+      if (set_.insert(v).second) {
+        temp_pos = deque_.insert(temp_pos, std::forward<decltype(v)>(v));
+        if (!any_inserted) {
+          first_inserted_index = temp_pos - deque_.cbegin();
+          any_inserted = true;
+        }
+        ++temp_pos;
+      }
+    }
+    return any_inserted ? first_inserted_index + deque_.cbegin()
+                        : pos_index + deque_.cbegin();
+  }
+#endif
 
   template <class... Args>
   std::pair<const_iterator, bool> emplace(const_iterator pos, Args&&... args) {
@@ -245,6 +279,25 @@ class deque_of_unique {
     return true;
   }
 
+#if __cplusplus >= 202302L
+  template <std::ranges::input_range R>
+  void prepend_range(R&& rng) {
+    std::deque<std::ranges::range_value_t<R>> tmp;
+    unordered_set_type seen(0, set_.hash_function(), set_.key_eq());
+    for (auto&& v : std::forward<R>(rng)) {
+      if (!set_.count(v) && seen.insert(v).second) tmp.push_back(v);
+    }
+    for (auto it = tmp.rbegin(); it != tmp.rend(); ++it)
+      push_front(std::move(*it));
+  }
+
+  template <std::ranges::input_range R>
+  void append_range(R&& rng) {
+    for (auto&& v : std::forward<R>(rng))
+      push_back(std::forward<decltype(v)>(v));
+  }
+#endif
+
  private:
   template <class input_it>
   void _push_back(input_it first, input_it last) {
@@ -338,6 +391,26 @@ class deque_of_unique {
     }
   bool contains(const K& x) const {
     return set_.contains(x);
+  }
+#endif
+
+  std::pair<const_iterator, const_iterator> equal_range(
+      const key_type& key) const {
+    auto it = find(key);
+    if (it == cend()) return {cend(), cend()};
+    return {it, it + 1};
+  }
+
+#if __cplusplus >= 202002L
+  template <class K>
+    requires requires {
+      typename Hash::is_transparent;
+      typename KeyEqual::is_transparent;
+    }
+  std::pair<const_iterator, const_iterator> equal_range(const K& x) const {
+    auto it = find(x);
+    if (it == cend()) return {cend(), cend()};
+    return {it, it + 1};
   }
 #endif
 

--- a/src/vectorofunique.h
+++ b/src/vectorofunique.h
@@ -10,10 +10,12 @@
 #include <ranges>
 #endif
 
+#ifndef NOEXCEPT_CXX17
 #if __cplusplus >= 201703L
 #define NOEXCEPT_CXX17 noexcept
 #else
 #define NOEXCEPT_CXX17
+#endif
 #endif
 
 namespace containerofunique {
@@ -229,12 +231,11 @@ class vector_of_unique {
   }
 
   bool push_back(T&& value) {
-    if (set_.count(value) > 0) {
-      return false;
+    if (set_.insert(value).second) {
+      vector_.push_back(std::move(value));
+      return true;
     }
-    set_.insert(value);
-    vector_.push_back(std::move(value));
-    return true;
+    return false;
   }
 
 #if __cplusplus >= 202302L
@@ -253,7 +254,7 @@ class vector_of_unique {
     }
   }
 
-  bool _push_back(const vector_of_unique<T, Hash>& other) {
+  bool _push_back(const vector_of_unique<T, Hash, KeyEqual>& other) {
     return _push_back(other.vector_);
   }
 

--- a/src/vectorofunique.h
+++ b/src/vectorofunique.h
@@ -284,9 +284,10 @@ class vector_of_unique {
     if (set_.count(x) == 0) {
       return cend();
     }
+    auto eq = set_.key_eq();
     auto it = cbegin();
     while (it != cend()) {
-      if (*it == x) {
+      if (eq(*it, x)) {
         return it;
       }
       it++;
@@ -298,9 +299,10 @@ class vector_of_unique {
     if (set_.count(x) == 0) {
       return cend();
     }
+    auto eq = set_.key_eq();
     auto it = cbegin();
     while (it != cend()) {
-      if (*it == x) {
+      if (eq(*it, x)) {
         return it;
       }
       it++;

--- a/src/vectorofunique.h
+++ b/src/vectorofunique.h
@@ -6,6 +6,9 @@
 #include <unordered_set>
 #include <utility>  // For std::swap
 #include <vector>
+#if __cplusplus >= 202302L
+#include <ranges>
+#endif
 
 #if __cplusplus >= 201703L
 #define NOEXCEPT_CXX17 noexcept
@@ -70,6 +73,15 @@ class vector_of_unique {
     clear();
     _push_back(ilist.begin(), ilist.end());
   }
+
+#if __cplusplus >= 202302L
+  template <std::ranges::input_range R>
+  void assign_range(R&& rng) {
+    clear();
+    for (auto&& v : std::forward<R>(rng))
+      push_back(std::forward<decltype(v)>(v));
+  }
+#endif
 
   // Element access
   const_reference at(size_type pos) const { return vector_.at(pos); }
@@ -152,6 +164,28 @@ class vector_of_unique {
     return insert(pos, ilist.begin(), ilist.end());
   }
 
+#if __cplusplus >= 202302L
+  template <std::ranges::input_range R>
+  const_iterator insert_range(const_iterator pos, R&& rng) {
+    auto pos_index = pos - vector_.cbegin();
+    auto first_inserted_index = pos_index;
+    auto temp_pos = vector_.begin() + pos_index;
+    auto any_inserted = false;
+    for (auto&& v : std::forward<R>(rng)) {
+      if (set_.insert(v).second) {
+        temp_pos = vector_.insert(temp_pos, std::forward<decltype(v)>(v));
+        if (!any_inserted) {
+          first_inserted_index = temp_pos - vector_.cbegin();
+          any_inserted = true;
+        }
+        ++temp_pos;
+      }
+    }
+    return any_inserted ? first_inserted_index + vector_.cbegin()
+                        : pos_index + vector_.cbegin();
+  }
+#endif
+
   template <class... Args>
   std::pair<const_iterator, bool> emplace(const_iterator pos, Args&&... args) {
     if (set_.emplace(args...).second) {
@@ -202,6 +236,14 @@ class vector_of_unique {
     vector_.push_back(std::move(value));
     return true;
   }
+
+#if __cplusplus >= 202302L
+  template <std::ranges::input_range R>
+  void append_range(R&& rng) {
+    for (auto&& v : std::forward<R>(rng))
+      push_back(std::forward<decltype(v)>(v));
+  }
+#endif
 
  private:
   template <class input_it>
@@ -296,6 +338,26 @@ class vector_of_unique {
     }
   bool contains(const K& x) const {
     return set_.contains(x);
+  }
+#endif
+
+  std::pair<const_iterator, const_iterator> equal_range(
+      const key_type& key) const {
+    auto it = find(key);
+    if (it == cend()) return {cend(), cend()};
+    return {it, it + 1};
+  }
+
+#if __cplusplus >= 202002L
+  template <class K>
+    requires requires {
+      typename Hash::is_transparent;
+      typename KeyEqual::is_transparent;
+    }
+  std::pair<const_iterator, const_iterator> equal_range(const K& x) const {
+    auto it = find(x);
+    if (it == cend()) return {cend(), cend()};
+    return {it, it + 1};
   }
 #endif
 

--- a/tests/test_dequeofunique.cpp
+++ b/tests/test_dequeofunique.cpp
@@ -1748,6 +1748,13 @@ TEST(DequeOfUniqueTest, AssignRange_ClearsExisting) {
   EXPECT_EQ(dou.front(), 1);
 }
 
+TEST(DequeOfUniqueTest, AssignRange_IntraRangeDuplicates) {
+  deque_of_unique<int> dou;
+  std::vector<int> src = {1, 2, 1, 3, 2};
+  dou.assign_range(src);
+  EXPECT_EQ(dou.deque(), std::deque<int>({1, 2, 3}));
+}
+
 TEST(DequeOfUniqueTest, InsertRange_Basic) {
   deque_of_unique<int> dou = {1, 3};
   std::vector<int> src = {2};
@@ -1759,6 +1766,13 @@ TEST(DequeOfUniqueTest, InsertRange_SkipsDuplicates) {
   deque_of_unique<int> dou = {1, 2, 3};
   std::vector<int> src = {2, 4};
   dou.insert_range(dou.cend(), src);
+  EXPECT_EQ(dou.deque(), std::deque<int>({1, 2, 3, 4}));
+}
+
+TEST(DequeOfUniqueTest, InsertRange_IntraRangeDuplicates) {
+  deque_of_unique<int> dou = {1, 4};
+  std::vector<int> src = {2, 3, 2};
+  dou.insert_range(dou.cbegin() + 1, src);
   EXPECT_EQ(dou.deque(), std::deque<int>({1, 2, 3, 4}));
 }
 
@@ -1774,6 +1788,13 @@ TEST(DequeOfUniqueTest, AppendRange_SkipsDuplicates) {
   std::vector<int> src = {2, 3};
   dou.append_range(src);
   EXPECT_EQ(dou.deque(), std::deque<int>({1, 2, 3}));
+}
+
+TEST(DequeOfUniqueTest, AppendRange_IntraRangeDuplicates) {
+  deque_of_unique<int> dou = {1, 2};
+  std::vector<int> src = {3, 4, 3};
+  dou.append_range(src);
+  EXPECT_EQ(dou.deque(), std::deque<int>({1, 2, 3, 4}));
 }
 
 TEST(DequeOfUniqueTest, PrependRange_Basic) {
@@ -1830,6 +1851,7 @@ using CaseInsensitiveDeque =
 
 TEST(DequeOfUniqueTest, CustomKeyEqual_CopyConstructor) {
   CaseInsensitiveDeque d1 = {"hello", "World"};
+  // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
   CaseInsensitiveDeque d2 = d1;
   EXPECT_EQ(d2.deque(), d1.deque());
   EXPECT_EQ(d2.size(), 2u);
@@ -1837,6 +1859,7 @@ TEST(DequeOfUniqueTest, CustomKeyEqual_CopyConstructor) {
 
 TEST(DequeOfUniqueTest, CustomKeyEqual_CopyConstructorRejectsDuplicates) {
   CaseInsensitiveDeque d1 = {"hello", "HELLO", "World"};
+  // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
   CaseInsensitiveDeque d2 = d1;
   EXPECT_EQ(d2.deque(), (std::deque<std::string>{"hello", "World"}));
 }
@@ -1847,3 +1870,78 @@ TEST(DequeOfUniqueTest, CustomKeyEqual_CopyAssignment) {
   d2 = d1;
   EXPECT_EQ(d2.deque(), d1.deque());
 }
+
+TEST(DequeOfUniqueTest, CustomKeyEqual_MoveConstructor) {
+  CaseInsensitiveDeque d1 = {"hello", "World"};
+  CaseInsensitiveDeque d2 = std::move(d1);
+  EXPECT_EQ(d2.deque(), (std::deque<std::string>{"hello", "World"}));
+  EXPECT_TRUE(d1.empty());
+}
+
+TEST(DequeOfUniqueTest, CustomKeyEqual_PushBack) {
+  CaseInsensitiveDeque d;
+  EXPECT_TRUE(d.push_back("hello"));
+  EXPECT_FALSE(d.push_back("HELLO"));
+  EXPECT_FALSE(d.push_back("Hello"));
+  EXPECT_EQ(d.size(), 1u);
+}
+
+TEST(DequeOfUniqueTest, CustomKeyEqual_PushFront) {
+  CaseInsensitiveDeque d;
+  EXPECT_TRUE(d.push_front("hello"));
+  EXPECT_FALSE(d.push_front("HELLO"));
+  EXPECT_FALSE(d.push_front("Hello"));
+  EXPECT_EQ(d.size(), 1u);
+}
+
+TEST(DequeOfUniqueTest, CustomKeyEqual_Find) {
+  CaseInsensitiveDeque d = {"hello", "World"};
+  EXPECT_NE(d.find(std::string("HELLO")), d.cend());
+  EXPECT_NE(d.find(std::string("world")), d.cend());
+  EXPECT_EQ(d.find(std::string("missing")), d.cend());
+}
+
+#if __cplusplus >= 202002L
+TEST(DequeOfUniqueTest, CustomKeyEqual_Contains) {
+  CaseInsensitiveDeque d = {"hello", "World"};
+  EXPECT_TRUE(d.contains(std::string("HELLO")));
+  EXPECT_TRUE(d.contains(std::string("world")));
+  EXPECT_FALSE(d.contains(std::string("missing")));
+}
+#endif
+
+TEST(DequeOfUniqueTest, CustomKeyEqual_Erase) {
+  CaseInsensitiveDeque d = {"hello", "World", "foo"};
+  erase(d, std::string("HELLO"));
+  EXPECT_EQ(d.deque(), (std::deque<std::string>{"World", "foo"}));
+}
+
+#if __cplusplus >= 202302L
+TEST(DequeOfUniqueTest, AssignRange_EmptyRange) {
+  deque_of_unique<int> dou = {1, 2, 3};
+  std::vector<int> src;
+  dou.assign_range(src);
+  EXPECT_TRUE(dou.empty());
+}
+
+TEST(DequeOfUniqueTest, InsertRange_EmptyRange) {
+  deque_of_unique<int> dou = {1, 3};
+  std::vector<int> src;
+  dou.insert_range(dou.cbegin() + 1, src);
+  EXPECT_EQ(dou.deque(), std::deque<int>({1, 3}));
+}
+
+TEST(DequeOfUniqueTest, AppendRange_EmptyRange) {
+  deque_of_unique<int> dou = {1, 2};
+  std::vector<int> src;
+  dou.append_range(src);
+  EXPECT_EQ(dou.deque(), std::deque<int>({1, 2}));
+}
+
+TEST(DequeOfUniqueTest, PrependRange_EmptyRange) {
+  deque_of_unique<int> dou = {1, 2};
+  std::vector<int> src;
+  dou.prepend_range(src);
+  EXPECT_EQ(dou.deque(), std::deque<int>({1, 2}));
+}
+#endif

--- a/tests/test_dequeofunique.cpp
+++ b/tests/test_dequeofunique.cpp
@@ -1837,11 +1837,13 @@ struct CaseInsensitiveHash {
 
 struct CaseInsensitiveEqual {
   bool operator()(const std::string& a, const std::string& b) const {
-    if (a.size() != b.size()) return false;
-    for (size_t i = 0; i < a.size(); ++i)
+    if (a.size() != b.size()) { return false; }
+    for (size_t i = 0; i < a.size(); ++i) {
       if (::tolower(static_cast<unsigned char>(a[i])) !=
-          ::tolower(static_cast<unsigned char>(b[i])))
+          ::tolower(static_cast<unsigned char>(b[i]))) {
         return false;
+      }
+    }
     return true;
   }
 };
@@ -1875,6 +1877,7 @@ TEST(DequeOfUniqueTest, CustomKeyEqual_MoveConstructor) {
   CaseInsensitiveDeque d1 = {"hello", "World"};
   CaseInsensitiveDeque d2 = std::move(d1);
   EXPECT_EQ(d2.deque(), (std::deque<std::string>{"hello", "World"}));
+  // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move,-warnings-as-errors)
   EXPECT_TRUE(d1.empty());
 }
 

--- a/tests/test_dequeofunique.cpp
+++ b/tests/test_dequeofunique.cpp
@@ -1837,7 +1837,9 @@ struct CaseInsensitiveHash {
 
 struct CaseInsensitiveEqual {
   bool operator()(const std::string& a, const std::string& b) const {
-    if (a.size() != b.size()) { return false; }
+    if (a.size() != b.size()) {
+      return false;
+    }
     for (size_t i = 0; i < a.size(); ++i) {
       if (::tolower(static_cast<unsigned char>(a[i])) !=
           ::tolower(static_cast<unsigned char>(b[i]))) {

--- a/tests/test_dequeofunique.cpp
+++ b/tests/test_dequeofunique.cpp
@@ -1523,19 +1523,14 @@ TEST(DequeOfUniqueTest, Find_HeterogeneousLookup) {
 }
 
 // Negative: find<K>/contains<K> are not available without Hash::is_transparent.
-// Use a type with no implicit conversion to std::string so the non-transparent
-// find(const T&) overload cannot accept it via implicit conversion.
-struct DequeOpaqueKey {
-  std::string value;
-  explicit DequeOpaqueKey(const char* s) : value(s) {}
-};
 template <typename C, typename K>
 concept DequeCanFindWith = requires(const C& c, K k) { c.find(k); };
 template <typename C, typename K>
 concept DequeCanContainsWith = requires(const C& c, K k) { c.contains(k); };
-static_assert(!DequeCanFindWith<deque_of_unique<std::string>, DequeOpaqueKey>);
 static_assert(
-    !DequeCanContainsWith<deque_of_unique<std::string>, DequeOpaqueKey>);
+    !DequeCanFindWith<deque_of_unique<std::string>, std::string_view>);
+static_assert(
+    !DequeCanContainsWith<deque_of_unique<std::string>, std::string_view>);
 #endif
 
 TEST(DequeOfUniqueTest, NonmemberEraseWithStrings) {
@@ -1692,3 +1687,120 @@ TEST(DequeOfUniqueTest, EraseIf_RemainingElementsPreserveOrder) {
   erase_if(dou, [](int x) { return x % 2 == 0; });
   EXPECT_EQ(dou.deque(), std::deque<int>({1, 3, 5}));
 }
+
+TEST(DequeOfUniqueTest, EqualRange_Found) {
+  deque_of_unique<int> dou = {10, 20, 30};
+  auto [lo, hi] = dou.equal_range(20);
+  ASSERT_NE(lo, dou.cend());
+  EXPECT_EQ(*lo, 20);
+  EXPECT_EQ(hi, lo + 1);
+}
+
+TEST(DequeOfUniqueTest, EqualRange_NotFound) {
+  deque_of_unique<int> dou = {10, 20, 30};
+  auto [lo, hi] = dou.equal_range(99);
+  EXPECT_EQ(lo, dou.cend());
+  EXPECT_EQ(hi, dou.cend());
+}
+
+TEST(DequeOfUniqueTest, EqualRange_Empty) {
+  deque_of_unique<int> dou;
+  auto [lo, hi] = dou.equal_range(1);
+  EXPECT_EQ(lo, dou.cend());
+  EXPECT_EQ(hi, dou.cend());
+}
+
+#if __cplusplus >= 202002L
+TEST(DequeOfUniqueTest, EqualRange_HeterogeneousLookup) {
+  deque_of_unique<std::string, StringHash, StringEqual> dou = {"hello",
+                                                               "world"};
+  auto [lo, hi] = dou.equal_range(std::string_view("hello"));
+  ASSERT_NE(lo, dou.cend());
+  EXPECT_EQ(*lo, "hello");
+  EXPECT_EQ(hi, lo + 1);
+
+  auto [lo2, hi2] = dou.equal_range(std::string_view("missing"));
+  EXPECT_EQ(lo2, dou.cend());
+  EXPECT_EQ(hi2, dou.cend());
+}
+#endif
+
+#if __cplusplus >= 202302L
+TEST(DequeOfUniqueTest, AssignRange_Basic) {
+  deque_of_unique<int> dou = {1, 2, 3};
+  std::vector<int> src = {4, 5, 6};
+  dou.assign_range(src);
+  EXPECT_EQ(dou.deque(), std::deque<int>({4, 5, 6}));
+}
+
+TEST(DequeOfUniqueTest, AssignRange_Deduplicates) {
+  deque_of_unique<int> dou;
+  std::vector<int> src = {1, 2, 2, 3, 1};
+  dou.assign_range(src);
+  EXPECT_EQ(dou.deque(), std::deque<int>({1, 2, 3}));
+}
+
+TEST(DequeOfUniqueTest, AssignRange_ClearsExisting) {
+  deque_of_unique<int> dou = {10, 20, 30};
+  std::vector<int> src = {1};
+  dou.assign_range(src);
+  EXPECT_EQ(dou.size(), 1);
+  EXPECT_EQ(dou.front(), 1);
+}
+
+TEST(DequeOfUniqueTest, InsertRange_Basic) {
+  deque_of_unique<int> dou = {1, 3};
+  std::vector<int> src = {2};
+  dou.insert_range(dou.cbegin() + 1, src);
+  EXPECT_EQ(dou.deque(), std::deque<int>({1, 2, 3}));
+}
+
+TEST(DequeOfUniqueTest, InsertRange_SkipsDuplicates) {
+  deque_of_unique<int> dou = {1, 2, 3};
+  std::vector<int> src = {2, 4};
+  dou.insert_range(dou.cend(), src);
+  EXPECT_EQ(dou.deque(), std::deque<int>({1, 2, 3, 4}));
+}
+
+TEST(DequeOfUniqueTest, AppendRange_Basic) {
+  deque_of_unique<int> dou = {1, 2};
+  std::vector<int> src = {3, 4};
+  dou.append_range(src);
+  EXPECT_EQ(dou.deque(), std::deque<int>({1, 2, 3, 4}));
+}
+
+TEST(DequeOfUniqueTest, AppendRange_SkipsDuplicates) {
+  deque_of_unique<int> dou = {1, 2};
+  std::vector<int> src = {2, 3};
+  dou.append_range(src);
+  EXPECT_EQ(dou.deque(), std::deque<int>({1, 2, 3}));
+}
+
+TEST(DequeOfUniqueTest, PrependRange_Basic) {
+  deque_of_unique<int> dou = {3, 4};
+  std::vector<int> src = {1, 2};
+  dou.prepend_range(src);
+  EXPECT_EQ(dou.deque(), std::deque<int>({1, 2, 3, 4}));
+}
+
+TEST(DequeOfUniqueTest, PrependRange_SkipsDuplicates) {
+  deque_of_unique<int> dou = {2, 3};
+  std::vector<int> src = {1, 2};
+  dou.prepend_range(src);
+  EXPECT_EQ(dou.deque(), std::deque<int>({1, 2, 3}));
+}
+
+TEST(DequeOfUniqueTest, PrependRange_PreservesOrder) {
+  deque_of_unique<int> dou = {4, 5};
+  std::vector<int> src = {1, 2, 3};
+  dou.prepend_range(src);
+  EXPECT_EQ(dou.deque(), std::deque<int>({1, 2, 3, 4, 5}));
+}
+
+TEST(DequeOfUniqueTest, PrependRange_IntraRangeDuplicates) {
+  deque_of_unique<int> dou = {4, 5};
+  std::vector<int> src = {1, 2, 1};
+  dou.prepend_range(src);
+  EXPECT_EQ(dou.deque(), std::deque<int>({1, 2, 4, 5}));
+}
+#endif

--- a/tests/test_dequeofunique.cpp
+++ b/tests/test_dequeofunique.cpp
@@ -1804,3 +1804,46 @@ TEST(DequeOfUniqueTest, PrependRange_IntraRangeDuplicates) {
   EXPECT_EQ(dou.deque(), std::deque<int>({1, 2, 4, 5}));
 }
 #endif
+
+// Tests for non-default KeyEqual
+struct CaseInsensitiveHash {
+  size_t operator()(const std::string& s) const {
+    std::string lower = s;
+    std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+    return std::hash<std::string>{}(lower);
+  }
+};
+
+struct CaseInsensitiveEqual {
+  bool operator()(const std::string& a, const std::string& b) const {
+    if (a.size() != b.size()) return false;
+    for (size_t i = 0; i < a.size(); ++i)
+      if (::tolower(static_cast<unsigned char>(a[i])) !=
+          ::tolower(static_cast<unsigned char>(b[i])))
+        return false;
+    return true;
+  }
+};
+
+using CaseInsensitiveDeque =
+    deque_of_unique<std::string, CaseInsensitiveHash, CaseInsensitiveEqual>;
+
+TEST(DequeOfUniqueTest, CustomKeyEqual_CopyConstructor) {
+  CaseInsensitiveDeque d1 = {"hello", "World"};
+  CaseInsensitiveDeque d2 = d1;
+  EXPECT_EQ(d2.deque(), d1.deque());
+  EXPECT_EQ(d2.size(), 2u);
+}
+
+TEST(DequeOfUniqueTest, CustomKeyEqual_CopyConstructorRejectsDuplicates) {
+  CaseInsensitiveDeque d1 = {"hello", "HELLO", "World"};
+  CaseInsensitiveDeque d2 = d1;
+  EXPECT_EQ(d2.deque(), (std::deque<std::string>{"hello", "World"}));
+}
+
+TEST(DequeOfUniqueTest, CustomKeyEqual_CopyAssignment) {
+  CaseInsensitiveDeque d1 = {"foo", "Bar"};
+  CaseInsensitiveDeque d2;
+  d2 = d1;
+  EXPECT_EQ(d2.deque(), d1.deque());
+}

--- a/tests/test_vectorofunique.cpp
+++ b/tests/test_vectorofunique.cpp
@@ -1273,20 +1273,14 @@ TEST(VectorOfUniqueTest, Find_HeterogeneousLookup) {
 }
 
 // Negative: find<K>/contains<K> are not available without Hash::is_transparent.
-// Use a type with no implicit conversion to std::string so the non-transparent
-// find(const T&) overload cannot accept it via implicit conversion.
-struct VectorOpaqueKey {
-  std::string value;
-  explicit VectorOpaqueKey(const char* s) : value(s) {}
-};
 template <typename C, typename K>
 concept VectorCanFindWith = requires(const C& c, K k) { c.find(k); };
 template <typename C, typename K>
 concept VectorCanContainsWith = requires(const C& c, K k) { c.contains(k); };
 static_assert(
-    !VectorCanFindWith<vector_of_unique<std::string>, VectorOpaqueKey>);
+    !VectorCanFindWith<vector_of_unique<std::string>, std::string_view>);
 static_assert(
-    !VectorCanContainsWith<vector_of_unique<std::string>, VectorOpaqueKey>);
+    !VectorCanContainsWith<vector_of_unique<std::string>, std::string_view>);
 #endif
 
 TEST(VectorOfUniqueTest, NonmemberEraseWithStrings) {
@@ -1443,3 +1437,92 @@ TEST(VectorOfUniqueTest, EraseIf_RemainingElementsPreserveOrder) {
   erase_if(vou, [](int x) { return x % 2 == 0; });
   EXPECT_EQ(vou.vector(), std::vector<int>({1, 3, 5}));
 }
+
+TEST(VectorOfUniqueTest, EqualRange_Found) {
+  vector_of_unique<int> vou = {10, 20, 30};
+  auto [lo, hi] = vou.equal_range(20);
+  ASSERT_NE(lo, vou.cend());
+  EXPECT_EQ(*lo, 20);
+  EXPECT_EQ(hi, lo + 1);
+}
+
+TEST(VectorOfUniqueTest, EqualRange_NotFound) {
+  vector_of_unique<int> vou = {10, 20, 30};
+  auto [lo, hi] = vou.equal_range(99);
+  EXPECT_EQ(lo, vou.cend());
+  EXPECT_EQ(hi, vou.cend());
+}
+
+TEST(VectorOfUniqueTest, EqualRange_Empty) {
+  vector_of_unique<int> vou;
+  auto [lo, hi] = vou.equal_range(1);
+  EXPECT_EQ(lo, vou.cend());
+  EXPECT_EQ(hi, vou.cend());
+}
+
+#if __cplusplus >= 202002L
+TEST(VectorOfUniqueTest, EqualRange_HeterogeneousLookup) {
+  vector_of_unique<std::string, StringHash, StringEqual> vou = {"hello",
+                                                                "world"};
+  auto [lo, hi] = vou.equal_range(std::string_view("hello"));
+  ASSERT_NE(lo, vou.cend());
+  EXPECT_EQ(*lo, "hello");
+  EXPECT_EQ(hi, lo + 1);
+
+  auto [lo2, hi2] = vou.equal_range(std::string_view("missing"));
+  EXPECT_EQ(lo2, vou.cend());
+  EXPECT_EQ(hi2, vou.cend());
+}
+#endif
+
+#if __cplusplus >= 202302L
+TEST(VectorOfUniqueTest, AssignRange_Basic) {
+  vector_of_unique<int> vou = {1, 2, 3};
+  std::vector<int> src = {4, 5, 6};
+  vou.assign_range(src);
+  EXPECT_EQ(vou.vector(), std::vector<int>({4, 5, 6}));
+}
+
+TEST(VectorOfUniqueTest, AssignRange_Deduplicates) {
+  vector_of_unique<int> vou;
+  std::vector<int> src = {1, 2, 2, 3, 1};
+  vou.assign_range(src);
+  EXPECT_EQ(vou.vector(), std::vector<int>({1, 2, 3}));
+}
+
+TEST(VectorOfUniqueTest, AssignRange_ClearsExisting) {
+  vector_of_unique<int> vou = {10, 20, 30};
+  std::vector<int> src = {1};
+  vou.assign_range(src);
+  EXPECT_EQ(vou.size(), 1);
+  EXPECT_EQ(vou.front(), 1);
+}
+
+TEST(VectorOfUniqueTest, InsertRange_Basic) {
+  vector_of_unique<int> vou = {1, 3};
+  std::vector<int> src = {2};
+  vou.insert_range(vou.cbegin() + 1, src);
+  EXPECT_EQ(vou.vector(), std::vector<int>({1, 2, 3}));
+}
+
+TEST(VectorOfUniqueTest, InsertRange_SkipsDuplicates) {
+  vector_of_unique<int> vou = {1, 2, 3};
+  std::vector<int> src = {2, 4};
+  vou.insert_range(vou.cend(), src);
+  EXPECT_EQ(vou.vector(), std::vector<int>({1, 2, 3, 4}));
+}
+
+TEST(VectorOfUniqueTest, AppendRange_Basic) {
+  vector_of_unique<int> vou = {1, 2};
+  std::vector<int> src = {3, 4};
+  vou.append_range(src);
+  EXPECT_EQ(vou.vector(), std::vector<int>({1, 2, 3, 4}));
+}
+
+TEST(VectorOfUniqueTest, AppendRange_SkipsDuplicates) {
+  vector_of_unique<int> vou = {1, 2};
+  std::vector<int> src = {2, 3};
+  vou.append_range(src);
+  EXPECT_EQ(vou.vector(), std::vector<int>({1, 2, 3}));
+}
+#endif

--- a/tests/test_vectorofunique.cpp
+++ b/tests/test_vectorofunique.cpp
@@ -1559,7 +1559,9 @@ struct CaseInsensitiveHashV {
 
 struct CaseInsensitiveEqualV {
   bool operator()(const std::string& a, const std::string& b) const {
-    if (a.size() != b.size()) { return false; }
+    if (a.size() != b.size()) {
+      return false;
+    }
     for (size_t i = 0; i < a.size(); ++i) {
       if (::tolower(static_cast<unsigned char>(a[i])) !=
           ::tolower(static_cast<unsigned char>(b[i]))) {

--- a/tests/test_vectorofunique.cpp
+++ b/tests/test_vectorofunique.cpp
@@ -1559,11 +1559,13 @@ struct CaseInsensitiveHashV {
 
 struct CaseInsensitiveEqualV {
   bool operator()(const std::string& a, const std::string& b) const {
-    if (a.size() != b.size()) return false;
-    for (size_t i = 0; i < a.size(); ++i)
+    if (a.size() != b.size()) { return false; }
+    for (size_t i = 0; i < a.size(); ++i) {
       if (::tolower(static_cast<unsigned char>(a[i])) !=
-          ::tolower(static_cast<unsigned char>(b[i])))
+          ::tolower(static_cast<unsigned char>(b[i]))) {
         return false;
+      }
+    }
     return true;
   }
 };
@@ -1597,6 +1599,7 @@ TEST(VectorOfUniqueTest, CustomKeyEqual_MoveConstructor) {
   CaseInsensitiveVector v1 = {"hello", "World"};
   CaseInsensitiveVector v2 = std::move(v1);
   EXPECT_EQ(v2.vector(), (std::vector<std::string>{"hello", "World"}));
+  // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move,-warnings-as-errors)
   EXPECT_TRUE(v1.empty());
 }
 

--- a/tests/test_vectorofunique.cpp
+++ b/tests/test_vectorofunique.cpp
@@ -1498,6 +1498,13 @@ TEST(VectorOfUniqueTest, AssignRange_ClearsExisting) {
   EXPECT_EQ(vou.front(), 1);
 }
 
+TEST(VectorOfUniqueTest, AssignRange_IntraRangeDuplicates) {
+  vector_of_unique<int> vou;
+  std::vector<int> src = {1, 2, 1, 3, 2};
+  vou.assign_range(src);
+  EXPECT_EQ(vou.vector(), std::vector<int>({1, 2, 3}));
+}
+
 TEST(VectorOfUniqueTest, InsertRange_Basic) {
   vector_of_unique<int> vou = {1, 3};
   std::vector<int> src = {2};
@@ -1509,6 +1516,13 @@ TEST(VectorOfUniqueTest, InsertRange_SkipsDuplicates) {
   vector_of_unique<int> vou = {1, 2, 3};
   std::vector<int> src = {2, 4};
   vou.insert_range(vou.cend(), src);
+  EXPECT_EQ(vou.vector(), std::vector<int>({1, 2, 3, 4}));
+}
+
+TEST(VectorOfUniqueTest, InsertRange_IntraRangeDuplicates) {
+  vector_of_unique<int> vou = {1, 4};
+  std::vector<int> src = {2, 3, 2};
+  vou.insert_range(vou.cbegin() + 1, src);
   EXPECT_EQ(vou.vector(), std::vector<int>({1, 2, 3, 4}));
 }
 
@@ -1524,6 +1538,13 @@ TEST(VectorOfUniqueTest, AppendRange_SkipsDuplicates) {
   std::vector<int> src = {2, 3};
   vou.append_range(src);
   EXPECT_EQ(vou.vector(), std::vector<int>({1, 2, 3}));
+}
+
+TEST(VectorOfUniqueTest, AppendRange_IntraRangeDuplicates) {
+  vector_of_unique<int> vou = {1, 2};
+  std::vector<int> src = {3, 4, 3};
+  vou.append_range(src);
+  EXPECT_EQ(vou.vector(), std::vector<int>({1, 2, 3, 4}));
 }
 #endif
 
@@ -1552,6 +1573,7 @@ using CaseInsensitiveVector =
 
 TEST(VectorOfUniqueTest, CustomKeyEqual_CopyConstructor) {
   CaseInsensitiveVector v1 = {"hello", "World"};
+  // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
   CaseInsensitiveVector v2 = v1;
   EXPECT_EQ(v2.vector(), v1.vector());
   EXPECT_EQ(v2.size(), 2u);
@@ -1559,6 +1581,7 @@ TEST(VectorOfUniqueTest, CustomKeyEqual_CopyConstructor) {
 
 TEST(VectorOfUniqueTest, CustomKeyEqual_CopyConstructorRejectsDuplicates) {
   CaseInsensitiveVector v1 = {"hello", "HELLO", "World"};
+  // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
   CaseInsensitiveVector v2 = v1;
   EXPECT_EQ(v2.vector(), (std::vector<std::string>{"hello", "World"}));
 }
@@ -1569,3 +1592,63 @@ TEST(VectorOfUniqueTest, CustomKeyEqual_CopyAssignment) {
   v2 = v1;
   EXPECT_EQ(v2.vector(), v1.vector());
 }
+
+TEST(VectorOfUniqueTest, CustomKeyEqual_MoveConstructor) {
+  CaseInsensitiveVector v1 = {"hello", "World"};
+  CaseInsensitiveVector v2 = std::move(v1);
+  EXPECT_EQ(v2.vector(), (std::vector<std::string>{"hello", "World"}));
+  EXPECT_TRUE(v1.empty());
+}
+
+TEST(VectorOfUniqueTest, CustomKeyEqual_PushBack) {
+  CaseInsensitiveVector v;
+  EXPECT_TRUE(v.push_back("hello"));
+  EXPECT_FALSE(v.push_back("HELLO"));
+  EXPECT_FALSE(v.push_back("Hello"));
+  EXPECT_EQ(v.size(), 1u);
+}
+
+TEST(VectorOfUniqueTest, CustomKeyEqual_Find) {
+  CaseInsensitiveVector v = {"hello", "World"};
+  EXPECT_NE(v.find(std::string("HELLO")), v.cend());
+  EXPECT_NE(v.find(std::string("world")), v.cend());
+  EXPECT_EQ(v.find(std::string("missing")), v.cend());
+}
+
+#if __cplusplus >= 202002L
+TEST(VectorOfUniqueTest, CustomKeyEqual_Contains) {
+  CaseInsensitiveVector v = {"hello", "World"};
+  EXPECT_TRUE(v.contains(std::string("HELLO")));
+  EXPECT_TRUE(v.contains(std::string("world")));
+  EXPECT_FALSE(v.contains(std::string("missing")));
+}
+#endif
+
+TEST(VectorOfUniqueTest, CustomKeyEqual_Erase) {
+  CaseInsensitiveVector v = {"hello", "World", "foo"};
+  erase(v, std::string("HELLO"));
+  EXPECT_EQ(v.vector(), (std::vector<std::string>{"World", "foo"}));
+}
+
+#if __cplusplus >= 202302L
+TEST(VectorOfUniqueTest, AssignRange_EmptyRange) {
+  vector_of_unique<int> vou = {1, 2, 3};
+  std::vector<int> src;
+  vou.assign_range(src);
+  EXPECT_TRUE(vou.empty());
+}
+
+TEST(VectorOfUniqueTest, InsertRange_EmptyRange) {
+  vector_of_unique<int> vou = {1, 3};
+  std::vector<int> src;
+  vou.insert_range(vou.cbegin() + 1, src);
+  EXPECT_EQ(vou.vector(), std::vector<int>({1, 3}));
+}
+
+TEST(VectorOfUniqueTest, AppendRange_EmptyRange) {
+  vector_of_unique<int> vou = {1, 2};
+  std::vector<int> src;
+  vou.append_range(src);
+  EXPECT_EQ(vou.vector(), std::vector<int>({1, 2}));
+}
+#endif

--- a/tests/test_vectorofunique.cpp
+++ b/tests/test_vectorofunique.cpp
@@ -1526,3 +1526,46 @@ TEST(VectorOfUniqueTest, AppendRange_SkipsDuplicates) {
   EXPECT_EQ(vou.vector(), std::vector<int>({1, 2, 3}));
 }
 #endif
+
+// Tests for non-default KeyEqual
+struct CaseInsensitiveHashV {
+  size_t operator()(const std::string& s) const {
+    std::string lower = s;
+    std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+    return std::hash<std::string>{}(lower);
+  }
+};
+
+struct CaseInsensitiveEqualV {
+  bool operator()(const std::string& a, const std::string& b) const {
+    if (a.size() != b.size()) return false;
+    for (size_t i = 0; i < a.size(); ++i)
+      if (::tolower(static_cast<unsigned char>(a[i])) !=
+          ::tolower(static_cast<unsigned char>(b[i])))
+        return false;
+    return true;
+  }
+};
+
+using CaseInsensitiveVector =
+    vector_of_unique<std::string, CaseInsensitiveHashV, CaseInsensitiveEqualV>;
+
+TEST(VectorOfUniqueTest, CustomKeyEqual_CopyConstructor) {
+  CaseInsensitiveVector v1 = {"hello", "World"};
+  CaseInsensitiveVector v2 = v1;
+  EXPECT_EQ(v2.vector(), v1.vector());
+  EXPECT_EQ(v2.size(), 2u);
+}
+
+TEST(VectorOfUniqueTest, CustomKeyEqual_CopyConstructorRejectsDuplicates) {
+  CaseInsensitiveVector v1 = {"hello", "HELLO", "World"};
+  CaseInsensitiveVector v2 = v1;
+  EXPECT_EQ(v2.vector(), (std::vector<std::string>{"hello", "World"}));
+}
+
+TEST(VectorOfUniqueTest, CustomKeyEqual_CopyAssignment) {
+  CaseInsensitiveVector v1 = {"foo", "Bar"};
+  CaseInsensitiveVector v2;
+  v2 = v1;
+  EXPECT_EQ(v2.vector(), v1.vector());
+}


### PR DESCRIPTION
## Purpose

This PR incorporates all fixes identified during a Greptile full-codebase review (triggered via PR #39 base → `review/base`, subsequently rebased to `main`).

## Fixes from Greptile review

- **P1 — Copy constructor broken for non-default `KeyEqual`**: Fixed missing `KeyEqual` parameter in the `_push_back(const container<T, Hash>&)` private overload in both headers. Previously, the copy constructor would fail to compile for any instantiation with a custom `KeyEqual`.
- **P1 — `NOEXCEPT_CXX17` macro redefinition**: Wrapped both definitions in `#ifndef` guards. Previously, including both headers in the same translation unit triggered `-Wmacro-redefined`, which is a compile error under `-Werror`.
- **P2 — Inconsistent rvalue `push_back`/`push_front`**: Restored the single-step `set_.insert(value).second` pattern, consistent with the lvalue overloads. The previous two-step `count` + `insert` was unnecessary overhead.
- **P2 — Missing `std::forward` in `emplace`**: Won't fix. Using lvalue `args` for `set_.emplace` is intentional — forwarding would leave the args moved-from before the sequence container can use them.

## Additional fix

- **`find()` ignoring custom `KeyEqual`**: The non-transparent `find()` overloads were using `operator==` for element comparison instead of `set_.key_eq()`, causing `find()` to silently ignore any custom `KeyEqual`.

## Tests added

For both `deque_of_unique` and `vector_of_unique`:

- `CustomKeyEqual_CopyConstructor`
- `CustomKeyEqual_CopyConstructorRejectsDuplicates`
- `CustomKeyEqual_CopyAssignment`
- `CustomKeyEqual_MoveConstructor`
- `CustomKeyEqual_PushBack`
- `CustomKeyEqual_PushFront`
- `CustomKeyEqual_Find`
- `CustomKeyEqual_Contains` (C++20)
- `CustomKeyEqual_Erase`